### PR TITLE
Fix filepaths in useful diagnostic section for logs

### DIFF
--- a/_pages/logs.md
+++ b/_pages/logs.md
@@ -122,7 +122,7 @@ This log contains information on actions such as:
 
 To find the errors related to a particular **Skill**, use this command once you have created an `ssh` connection: 
 
-`cat /var/log/mycroft-skills.log | grep -i error | grep -i SKILLNAME`
+`cat /var/log/mycroft/skills.log | grep -i error | grep -i SKILLNAME`
 
 where `SKILLNAME` is the name of the **Skill**. 
 
@@ -130,7 +130,7 @@ where `SKILLNAME` is the name of the **Skill**.
 
 If you are [developing new Skills for Mycroft](https://mycroft.ai/documentation/skills/developing-skills/), then we strongly recommend that you `tail` the `skills.log` log file as you are doing development work, so that you can easily observe any errors that your **Skill** is throwing. To do this, use this command: 
 
-`tail -f /var/log/skills.log`
+`tail -f /var/log/mycroft/skills.log`
 
 To stop `tail`ing the log, press Ctrl + C. 
 


### PR DESCRIPTION
## Description

I was trying to diagnose an error on my mark 1 and noticed that the filepaths were incorrect in the **useful diagnostic** section. Updated the paths to be the correct paths and now I get the output I was expecting (included below)

## Previous Behavior
```
root@mark_1:~# cat /var/log/mycroft-skills.log | grep -i error | grep -i picker
cat: /var/log/mycroft-skills.log: No such file or directory
```

```
root@mark_1:~# tail -f /var/log/skills.log
tail: cannot open _/var/log/skills.log_ for reading: No such file or directory
tail: no files remaining
```

## New Behavior

```
root@mark_1:~# cat /var/log/mycroft/skills.log | grep -i error | grep -i pick
03:55:04.319 - mycroft.skills.core:load_skill:166 - ERROR - Failed to load skill: pick-number.pcwii
PermissionError: [Errno 13] Permission denied: '/opt/mycroft/skills/pick-number.pcwii/settings.json'
03:55:15.213 - mycroft.skills.core:wrapper:1052 - ERROR - An error occurred while processing a request in Pick Number Skill
PermissionError: [Errno 13] Permission denied: '/opt/mycroft/skills/pick-number.pcwii/settings.json'
```
> Disregard the error, I installed the skill as the wrong user originally, but was able to fix that easily

```
root@mark_1:~# tail -f /var/log/mycroft/skills.log
04:37:02.455 - urllib3.connectionpool - DEBUG - Starting new HTTPS connection (1): api.mycroft.ai:443
04:37:02.921 - urllib3.connectionpool - DEBUG - https://api.mycroft.ai:443 "GET /v1/device/0b0cc4df-a286-4bb9-803d-ef1dfe1215d7/skill HTTP/1.1" 304 0
```

## Hardware

Mark 1 Mycroft