### PR TITLE
Document settingsmeta.yaml

### DIFF
--- a/_pages/msk.md
+++ b/_pages/msk.md
@@ -139,7 +139,7 @@ total 36
 4 -rw-rw-r--   1 kathyreid kathyreid   21 Jun  7 05:20 .gitignore
 4 -rw-rw-r--   1 kathyreid kathyreid  379 Jun  7 05:18 __init__.py
 4 -rw-rw-r--   1 kathyreid kathyreid  434 Jun  7 05:20 README.md
-4 -rw-rw-r--   1 kathyreid kathyreid 1301 Jun  7 05:20 settingsmeta.json
+4 -rw-rw-r--   1 kathyreid kathyreid 1301 Jun  7 05:20 settingsmeta.yaml
 4 drwxrwxr-x   3 kathyreid kathyreid 4096 Jun  7 05:20 vocab
 ```
 

--- a/_pages/skill-settings.md
+++ b/_pages/skill-settings.md
@@ -15,8 +15,8 @@ post_date: 2017-12-02 22:35:25
   * [How do I use Skill Settings?](#how-do-i-use-skill-settings)
     + [More information on Skill Settings](#more-information-on-skill-settings)
   * [settings.json](#settingsjson)
-  * [Web configurable Settings with `settingsmeta.json`](#web-configurable-settings-with-settingsmetajson)
-    + [More information on the `settingsmeta.json` file](#more-information-on-the-settingsmetajson-file)
+  * [Web configurable Settings with `settingsmeta` file](#web-configurable-settings-with-settingsmeta)
+    + [More information on the `settingsmeta` file](#more-information-on-the-settingsmeta-file)
       - [name (String)](#name-string)
       - [skillMetadata (Object)](#skillmetadata-object)
       - [sections (Array)](#sections-array)
@@ -33,9 +33,7 @@ They are a simple extension of the [Python `dict`](https://docs.python.org/2/lib
 
 class. Skill settings can also interact with a backend system to provide a graphical user interface (GUI) for Skills configuration. Skills configuration is done through metadata described in an optional
 
-`settingsmeta.json`
-
-file.
+`settingsmeta.json` or `settingsmeta.yaml` file.  
 
 ## How do I use Skill Settings?
 
@@ -79,15 +77,15 @@ _NOTE: The Skill directory should be owned by user `mycroft` and have group owne
 
 When a **Skill** is shut down - which usually happens when restarting a service, or reloading a **Skill** - it will create a `settings.json` file and store the dict data there. When a **Skill** loads, it reads the `settings.json` file and loads the settings into the **Skill**. Knowing this makes it easier to build and test **Skills**, because you can create the `settings.json` file first with settings in it, and use these in your Skills development, and then add in code later on that _writes_ to `settings.json`.
 
-## Web configurable Settings with `settingsmeta.json`
+## Web configurable Settings with `settingsmeta` file
 
 For some **Skills**, the User may need to configure them before they are usable. Examples include **Skills** where an API token or login is required.
 
-This functionality is provided by the `settingsmeta.json` file. This file defines settings and their values that the User can configure on [home.mycroft.ai](https://home.mycroft.ai). Mycroft will automatically synchronize the `settings.json` file with the settings that the User can configure on [home.mycroft.ai](https://home.mycroft.ai).
+This functionality is provided by the `settingsmeta` file. This file defines settings and their values that the User can configure on [home.mycroft.ai](https://home.mycroft.ai). Mycroft will automatically synchronize the `settings.json` file with the settings that the User can configure on [home.mycroft.ai](https://home.mycroft.ai).
 
-To use this feature, you need to have a `settingsmeta.json` file in the root directory of the **Skill**. The `settingsmeta.json` file _must_ follow a specific structure.
+To use this feature, you need to have a `settingsmeta.json` or `settingsmeta.yaml` file in the root directory of the **Skill**. The `settingsmeta` file _must_ follow a specific structure.
 
-Below is an example of this structure from the `pianobar-skill`. You can see the [code for this **Skill**](https://github.com/ethanaward/pianobar-skill) - it has excellent example on how to use web configurable **Skill Settings**.
+Below is a JSON example of this structure from the `pianobar-skill`. You can see the [code for this **Skill**](https://github.com/ethanaward/pianobar-skill) - it has excellent example on how to use web configurable **Skill Settings**.
 
 ```json
 {
@@ -115,7 +113,26 @@ Below is an example of this structure from the `pianobar-skill`. You can see the
     }
 }
 ```
-### More information on the `settingsmeta.json` file
+Here is the same set of settings, as it would be configured with YAML:
+
+```yaml
+name: Pandora
+skillMetadata:
+   sections:
+      - name: Login
+        fields:
+          - name: email
+            type: email
+            label: Email
+            value: ""
+          - name: password
+            type: password
+            label: Password
+            value: ""
+```
+### More information on the `settingsmeta` file
+
+You may use JSON or YAML to define your `settingsmeta` file. We recommend YAML, as most people find it easier to work with.
 
 #### name (String)
 The display name for this **Skill Setting** block. This will be shown on the [home.mycroft.ai](https://home.mycroft.ai) Skills page. The `name` can be multiple words, but should display on a single line.

--- a/_pages/skills-acceptance-process.md
+++ b/_pages/skills-acceptance-process.md
@@ -119,7 +119,7 @@ _NOTE: Skills that are installed by default vary by `enclosure` and can be found
 
 * Check `requirements.txt` and `requirements.sh` - are the required dependencies listed? If `requirements.sh` is used, is some form of conditional processing done to match against multiple distros? Often Skill Authors will add requirements.txt using only an “library=1.x.x” instead of “library >=1.x.x”. Check to make sure that here is an equal or greater than in the requirements to help future-proof the Skill, unless a _specific_ version is needed. 
 
-* Check `settingsmeta.json` - are the settings well laid out? Does the placeholder text make sense?
+* Check `settingsmeta` - are the settings well laid out? Does the placeholder text make sense?
 
 ### What are the labels used on the `mycroft-skills` repo?
 

--- a/_pages/skills-review-code-template.md
+++ b/_pages/skills-review-code-template.md
@@ -44,7 +44,7 @@ Check `requirements.txt` and `requirements.sh` - are the required dependencies l
 >
 
 - [ ] **Settings**  
-Is the `settingsmeta.json` file well laid out? If settings are not used, has the default file been deleted? If it is the default file, the first setting section will be called "Options << Name of section". >
+Is the `settingsmeta` file well laid out? If settings are not used, has the default file been deleted? If it is the default file, the first setting section will be called "Options << Name of section". >
 
 - [ ] **Integration Tests**  
 Does the skill include sufficient integration tests, included in the `test` folder?

--- a/_pages/skills-review-functional-template.md
+++ b/_pages/skills-review-functional-template.md
@@ -33,7 +33,7 @@ Check that the Skill installs using voice commands. Mycroft will get the user to
 > ```
 
 - [ ] **Settings**  
-If Skill includes a `settingsmeta.json` file - are the settings well laid out? Does the placeholder text make sense? This can also be checked on [home.mycroft.ai/#/skill](https://home.mycroft.ai/#/skill)
+If Skill includes a `settingsmeta` file - are the settings well laid out? Does the placeholder text make sense? This can also be checked on [home.mycroft.ai/#/skill](https://home.mycroft.ai/#/skill)
 
 >
 

--- a/_pages/skills-review-template.md
+++ b/_pages/skills-review-template.md
@@ -69,7 +69,7 @@ Check `requirements.txt` and `requirements.sh` - are the required dependencies l
 >
 
 - [ ] **Settings**  
-Is the `settingsmeta.json` file well laid out? If settings are not used, has the default file been deleted? If it is the default file, the first setting section will be called "Options << Name of section". >
+Is the `settingsmeta` file well laid out? If settings are not used, has the default file been deleted? If it is the default file, the first setting section will be called "Options << Name of section". >
 
 - [ ] **Integration Tests**  
 Does the skill include sufficient integration tests, included in the `test` folder?
@@ -139,7 +139,7 @@ Check that the Skill installs using voice commands. Mycroft will get the user to
 > ```
 
 - [ ] **Settings**  
-If Skill includes a `settingsmeta.json` file - are the settings well laid out? Does the placeholder text make sense? This can also be checked on [home.mycroft.ai/#/skill](https://home.mycroft.ai/#/skill)
+If Skill includes a `settingsmeta` file - are the settings well laid out? Does the placeholder text make sense? This can also be checked on [home.mycroft.ai/#/skill](https://home.mycroft.ai/#/skill)
 
 >
 


### PR DESCRIPTION
Per [this comment](https://github.com/MycroftAI/mycroft-core/pull/2113#issuecomment-491708908) from @forslund, documenting yaml as the preferred format for the settingsmeta file. If this is approved, I'll go ahead and update [mycroft-skills-kit](https://github.com/MycroftAI/mycroft-skills-kit/blob/d98b6fc18081d25c3903951e57bdb0ffc84da3f1/msk/actions/create.py#L81-L120) as well.