### PR TITLE
Fix refs to deprecated mycroft.skills.core module

### DIFF
--- a/_pages/fallback-skill.md
+++ b/_pages/fallback-skill.md
@@ -27,7 +27,7 @@ The Fallback **Skills** all have a priority and will be checked in order from lo
 Import the `FallbackSkill` base class:
 
 ```python
-from mycroft.skills.core import FallbackSkill
+from mycroft import FallbackSkill
 ```
 
 Create a derived class:

--- a/_pages/introduction-developing-skills.md
+++ b/_pages/introduction-developing-skills.md
@@ -215,7 +215,7 @@ Let's take a look:
 
 ```python
 from adapt.intent import IntentBuilder
-from mycroft.skills.core import MycroftSkill
+from mycroft import MycroftSkill
 from mycroft.util.log import getLogger
 ```
 

--- a/_pages/padatious.md
+++ b/_pages/padatious.md
@@ -119,7 +119,7 @@ A skill using Padatious is no different than previous skills except that `self.r
 For example, the Tomato Skill would be written as: 
 
 ```
-from mycroft.skills.core import MycroftSkill
+from mycroft import MycroftSkill
 
 class TomatoSkill(MycroftSkill):
     def __init__(self):


### PR DESCRIPTION
Remove references from tutorials to mycroft.skills.core module (depr.)

Do not remove references from troubleshooting.md, nor from blog posts

closes #128 