### PR TITLE
Update skill development intro with latest practices

### DIFF
--- a/docs/skill-development/introduction.md
+++ b/docs/skill-development/introduction.md
@@ -1,36 +1,40 @@
 ---
-description: ''
+description: >-
+  Explore the fundamental building blocks of a Skill, and the knowledge required to create meaningful and engaging voice interactions.
 ---
 
 # Introduction to Skill Development
+Mycroft Skills are the voice applications that provide different functionality for users. To create a Skill requires at least basic technical experience, a Mycroft installation or device, and an idea of what your Skill will do, and how people will use it.
 
-{% hint style="info" %}
-Are you looking for the [system-generated documentation for the Mycroft Skills API?](http://mycroft-core.readthedocs.io/en/stable/)
-{% endhint %}
+## Technical Requirements
 
-## Prerequisites
+### Python programming language
+Skills for Mycroft are written using the [Python programming language](https://www.python.org/). A simple Skill can be a great way for new developers to try Python out in a real project, whilst experienced programmers will quickly see the powerful possibilities available in a well crafted Skill.
 
-Before starting to develop **Skills** for Mycroft, you should already have these prerequisites:
+If you aren't familiar with the basics of Python, checkout our [list of Python tutorials and resources](python-resources.md) to get you started. If you've programmed in other object-oriented languages, like Javascript or C\#, then you'll be able to pick it up, but if you're totally new to programming, you might want to look at an [introductory programming course](https://www.edx.org/course/introduction-computer-science-mitx-6-00-1x-11).
 
-* You should have a basic understanding of the [Python programming language](https://www.python.org/).
-* You should be familiar with version control using [Git](https://git-scm.com/book/en/v2/Getting-Started-About-Version-Control), and [GitHub basics](https://guides.github.com/activities/hello-world/) such as forking and committing.
-* You should have a basic understanding of [regular expressions](https://regexr.com/).
-* You should have a basic understanding of [conversational user interface](https://en.wikipedia.org/wiki/Voice_user_interface), a subset of [user experience](https://en.wikipedia.org/wiki/User_experience).
+### Github account
+Skills are hosted on [Github](https://github.com), so you will need to create an account there if you don't already have one. It is good to have an understanding of the [GitHub basics](https://guides.github.com/activities/hello-world/), however the [Mycroft Skills Kit](mycroft-skills-kit.md) also automates some of the more complex aspects of managing a Github repository (or repo).
 
-## An overview of Mycroft components
+### Running Mycroft
+To test your Skill out, you will need to [setup a Mycroft device](../using-mycroft-ai/get-mycroft/README.md). This can be installed on your computer, a Raspberry Pi using Picroft, or a dedicated device like the Mark 1. Mycroft also comes with a number of helpful tools to create new Skills, host them on Github, run integration tests, and submit them for inclusion in the [Mycroft Marketplace](https://market.mycroft.ai). If you aren't yet familiar with how Mycroft works, check out the [overview of Mycroft components](http://mycroft.ai/documentation/mycroft-software-hardware/) to understand the many technologies that come together to provide an intelligent voice assistant.
 
-If you haven't yet read the [overview of Mycroft components](http://mycroft.ai/documentation/mycroft-software-hardware/), it's worth doing so.
+## What makes a good Skill?
 
-## What makes a good **Skill**?
+### Fulfilling a need the user has
+Good Skills meet one or more needs the user has. Popular Skills are popular because people use them frequently - for instance to set alarms, reminders, and to identify the time in other time zones. On the other hand, a Skill that, say, recites π to a 100 digits might be pretty cool, but when was the last time you needed to know π to 100 digits? Contrast that with the last time you set a reminder on your phone.
 
-There are many components to what makes a good **Skill**.
+### Having an easy to use voice interface
+Just like a web page that has thought put into the user interface is much more pleasant to use, a Skill that has a well designed voice interface is a delight, not a chore, to use. You should anticipate the task the user is trying to accomplish, and how to make that as straightforward as possible.
 
-* **Fulfilling a need the user has**: Good **Skills** meet one or more needs the user has. Popular **Skills** are popular because people use them frequently - for instance to set alarms, reminders, and to identify the time in other time zones. On the other hand, a **Skill** that, say, recites π to a 100 digits might be pretty cool, but when was the last time you needed to know π to 100 digits? Contrast that with the last time you set a reminder on your phone.
-* **Having an easy to use voice interface**: Just like a web page that has thought put into the user interface is much more pleasant to use, a **Skill** that has a well designed voice interface is a delight, not a chore, to use. You should anticipate the task the user is trying to accomplish, and how to make that as straightforward as possible.
+If you have an idea for a Skill, it's a great idea to join [Mycroft Chat](https://chat.mycroft.ai), specifically the [~skills](https://chat.mycroft.ai/community/channels/skills) channel, and share what your plans are. You'll be able to get constructive and helpful feedback on your Skill from an experienced community.
 
-If you have an idea for a **Skill**, it's a great idea to join [Mycroft Chat](https://chat.mycroft.ai), specifically the [~skills](https://chat.mycroft.ai/community/channels/skills) channel, and share what your plans are. You'll be able to get constructive and helpful feedback on your **Skill** from an experienced community.
+## Skill terminology
 
-## The Mycroft Skill Manager \(MSM\)
+You'll notice some new terms as you start to develop Skills.
 
-The [Mycroft Skills Manager](https://mycroft.ai/documentation/msm/) - MSM - is a tool that is being increasingly used to find, deploy and resolve dependencies within **Skills**. It is important that you make your Skills compliant with `msm` so that they are easy to find and install in the future.
+* **utterance** - An utterance is a phrase spoken by the User, after the User says the Wake Word. `what's the weather like in Toronto?` is an utterance.
+* **dialog** - A dialog is a phrase that is spoken by Mycroft. Different Skills will have different dialogs, depending on what the Skill does. For example, in a _weather_ Skill, a dialog might be `the.maximum.temperature.is.dialog`.
+* **intent** - Mycroft matches utterances that a User speaks with a Skill by determining an intent from the utterance. For example, if a User speaks `Hey Mycroft, what's the weather like in Toronto?` then the intent will be identified as _weather_ and matched with the _Weather Skill_. When you develop new Skills, you need to define new intents.
 
+If you encounter anything else you're not familiar with, checkout the [Mycroft Glossary](../about-mycroft-ai/glossary.md).

--- a/docs/skill-development/your-first-skill.md
+++ b/docs/skill-development/your-first-skill.md
@@ -1,136 +1,96 @@
 ---
 description: >-
-  In this introduction to developing Skills for Mycroft, learn the prerequisites
-  you'll need, and step through the basic anatomy of a Mycroft Skill.
+  Ready to create your first Skill? See how easy it is to get a new Skill up and running, then we will step through the basic anatomy of a Mycroft Skill.
 ---
 
 # Your First Skill
 
-This page will walk you through developing a new Mycroft **Skill**.
-
 ## Prerequisites
 
-It's a good idea to get prepared before writing your new **Skill**, as this will make your skill-writing experience go much smoother.
+If you haven't already, check out our [Introduction to Skill Development](introduction.md). This walk through assumes you:
+* Know some basic knowledge of [Python programming](https://www.python.org/),
+* have an account on [Github.com](https://github.com), and
+* have a [working version of Mycroft](../using-mycroft-ai/get-mycroft/README.md).
 
-* **Git** - You will need to know some basic Git commands in order to create a new **Skill** for Mycroft. If you're not familiar with Git, that's OK, but you _will_ need to have [Git installed on your system. ](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git).
-* **Python** - You will need to know some basic Python programming to get started. If you've programmed in other object-oriented languages, like Javascript or C\#, then you'll be able to pick it up, but if you're totally new to programming, you'll need to do an [introductory programming course](https://www.edx.org/course/introduction-computer-science-mitx-6-00-1x-11).
-* **Naming your Skill** - Choose a name for your **Skill** before creating a new repository. It's a good idea to check the [Mycroft Skills Repo](https://github.com/MycroftAI/mycroft-skills) so that you don't create a duplicate name.
-* **Set up your environment** - Most people will find it easiest to test new **Skills** by setting up [Mycroft for Linux](https://mycroft.ai/documentation/linux/). `cd` into the directory where you have `mycroft-core` installed and type `./start-mycroft.sh debug`. This should open a command line interface \(CLI\) like that shown below:
-
-![Starting mycroft-core in debug mode for Skills testing](https://mycroft.ai/wp-content/uploads/2017/12/mycroft-core-start-debug.png)
-
-* **Understand the flow of your Skill** - It's a good idea to write down on paper how your **Skill** will work, including
-  * What words will the User speak to activate the **Skill**?
+## Understand the flow of your Skill
+It's a good idea to start by writing down how your Skill will work, including
+  * What words will the User speak to activate the Skill?
   * What will Mycroft speak in response?
-  * What data will you need to deliver the **Skill**?
+  * What data will you need to deliver the Skill?
   * Will you need any additional packages or dependencies?
 
 Once you've given these some thought, you can get started.
 
-## Skill terminology
+## Mycroft Skills Kit (MSK)
+To setup the foundations of your Skill, we will use the [Mycroft Skills Kit (MSK)](mycroft-skills-kit.md) that comes installed with Mycroft. If you chose the defaults during installation, you can run MSK from your Terminal using the command: `mycroft-msk`. Running this command without any arguments will provide a brief overview of what you can do with MSK.
 
-You'll notice some new terms as you start to develop **Skills**.
+If you receive a "command not found", then you will need to run `msk` manually from your `mycroft-core` directory. Anytime you see `mycroft-msk` in our documentation you must replace this with:
 
-* **dialog** - A **dialog** is a phrase that is spoken by Mycroft. Different **Skills** will have different **dialogs**, depending on what the **Skill** does. For example, in a _weather_ **Skill**, a **dialog** might be `the.maximum.temperature.is.dialog`.
-* **intent** - Mycroft matches **utterances** that a User speaks with a **Skill** by determining an **intent** from the **utterance**. For example, if a User speaks `Hey Mycroft, what's the weather like in Toronto?` then the **intent** will be identified as _weather_ and matched with the _Weather Skill_. When you develop new **Skills**, you need to define new **intents**.
-* **utterance** - An **utterance** is a phrase spoken by the User, after the User says the **Wake Word**. `what's the weather like in Toronto?` is an **utterance**.
+### MSK Create
+`mycroft-msk create` is an interactive script that asks you a few questions and generates a new Skill template. This template can immediately be used as a Skill, however you will most likely want to extend its functionaity.
 
-## Make a new repo using the Template Skill
+To create your first Skill, you will be asked for a:
+1. Name
+  To be readable within the space available on the [Mycroft Skills Marketplace](https://market.mycroft.ai) the name should be short, generally under 22 characters in length. The name must also be unique. You can check the [Marketplace](https://market.mycroft.ai) to see what other Skills already exist.
+2. Example phrases (known as utterances)
+  Utterances that you expect Users to say to Mycroft, that your Skill will respond to.
+3. Response dialog
+  The dialog that your Skill will respond with.
+4. Short description
+  A one-line description, less than 40 characters long.
+5. Long description
+  This can be as short or as long as you like.
+6. Author
+  This is most often your name, and / or Github @username
+7. Categories
+  The [Mycroft Skills Marketplace](https://market.mycroft.ai) categories your Skill belongs to. It's important to note that the first category you select will be set as the default category. This is where your Skill will most often appear in the Marketplace.
+8. Tags
+  Tags provide an additional means for Users to search for or discover relevant Skills. Unlike categories, you can set your tags to anything you like.
 
-In GitHub, `fork` the [Mycroft Skills repo](https://github.com/MycroftAI/mycroft-skills/) into your own GitHub account.
+After inputting this data you will be asked if you would like a Github repo created for your Skill. This provides an easy way to store your Skill, and will be required if you choose to [publish your Skill in the Marketplace](marketplace-submission/README.md).
 
-Do this by clicking the 'Fork' button.
+If you have completed all of these steps, your Skill will have been created in the `/opt/mycroft/skills` directory on your device.
 
-![Forking the Mycroft Skills Repo](https://mycroft.ai/wp-content/uploads/2017/12/skills-forking-mycroft-skills-repo.png)
+## Structure of a Skill
 
-Then,
-
-`git clone`
-
-the repo you've just forked to your local machine.
-
-For example, if your GitHub username is "JaneBloggs" then you will need to
-
-`git clone`
-
-from [https://github.com/JaneBloggs/mycroft-skills.git](https://github.com/JaneBloggs/mycroft-skills.git)
-
-```bash
-$ git clone https://github.com/JaneBloggs/mycroft-skills.git
-Cloning into 'mycroft-skills'...
-remote: Counting objects: 1529, done.
-remote: Compressing objects: 100% (60/60), done.
-remote: Total 1529 (delta 42), reused 46 (delta 15), pack-reused 1451
-Receiving objects: 100% (1529/1529), 7.44 MiB | 565.00 KiB/s, done.
-Resolving deltas: 100% (709/709), done.
-Checking connectivity... done.
-```
-
-Now, we'll made a new repository for your **Skill**. The new repository has to follow a strict file structure. A **Template Skill** is available to clone from. If you're new to GitHub, you might find this guide on [how to make a repo](https://help.github.com/articles/create-a-repo/) useful.
-
-[Example Skill Template](https://github.com/MycroftAI/mycroft-skills/tree/19.02/00__skill_template)
-
-Copy the Template Skill into a new directory. Here, we've called the new Skill `skill-hello-world`, but your **Skill** will have a different name.
+If we now navigate to our new Skill, we can see that it is made up of a number of files and folders.
 
 ```text
-$ cp -R 00__skill_template skill-hello-world
-$ ls -las
+$ ls -l
+total 20
+drwxr-xr-x 3 kris kris 4096 Oct  8 22:21 dialog
+-rw-r--r-- 1 kris kris  299 Oct  8 22:21 __init__.py
+-rw-r--r-- 1 kris kris 9482 Oct  8 22:21 LICENSE
+-rw-r--r-- 1 kris kris  283 Oct  8 22:21 README.md
+-rw-r--r-- 1 kris kris  642 Oct  8 22:21 settingsmeta.yaml
+drwxr-xr-x 3 kris kris 4096 Oct  8 22:21 vocab
 ```
 
-### Structure of the **Skill** repo
+We will look at each of these in turn.
 
-The structure of the **Template Skill** directory looks like this:
+### `vocab`, `dialog`, and `locale` directories
 
-```text
-$ ls -las
-total 128
- 8 drwxrwxr-x   5 kathyreid kathyreid  4096 Oct 27 00:22 .
- 8 drwxrwxr-x 136 kathyreid kathyreid  4096 Oct 27 00:22 ..
- 8 drwxrwxr-x   3 kathyreid kathyreid  4096 Oct 27 00:22 dialog
- 8 -rw-rw-r--   1 kathyreid kathyreid  3768 Oct 27 00:22 __init__.py
-56 -rw-rw-r--   1 kathyreid kathyreid 49360 Oct 27 00:22 LICENSE
- 8 -rw-rw-r--   1 kathyreid kathyreid   187 Oct 27 00:22 README.md
- 8 -rw-rw-r--   1 kathyreid kathyreid   116 Oct 27 00:22 requirements.sh
- 8 -rw-rw-r--   1 kathyreid kathyreid    79 Oct 27 00:22 requirements.txt
- 8 drwxrwxr-x   3 kathyreid kathyreid  4096 Oct 27 00:22 test
- 8 drwxrwxr-x   3 kathyreid kathyreid  4096 Oct 27 00:22 vocab
-```
+The `dialog`, `vocab`, and `locale` directories contain subdirectories for each spoken language the skill supports. The subdirectories are named using the [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag) for the language. For example, Brazilian Portugues is 'pt-br', German is 'de-de', and Australian English is 'en-au'.
 
-#### `dialog` directory
-
-The `dialog` directory contains subdirectories for each spoken language the skill supports. Each subdirectory has `.dialog` files which specify what Mycroft should say when a **Skill** is executed.
-
-The subdirectories are named using the [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag) for the language. For example, Brazilian Portugues is 'pt-br', German is 'de-de', and Australian English is 'en-au'.
-
-Here is an example where one language is supported. By default, the **Template Skill** contains one subdirectory for United States English - 'en-us'. If more languages were supported, then there would be additional language directories.
+By default, your new Skill contains one subdirectory for United States English - 'en-us'. If more languages were supported, then there would be additional language directories.
 
 ```bash
-$ ls -las -R
-.:
-total 24
-8 drwxrwxr-x 3 kathyreid kathyreid 4096 Oct 27 23:32 .
-8 drwxrwxr-x 6 kathyreid kathyreid 4096 Oct 27 23:32 ..
-8 drwxrwxr-x 2 kathyreid kathyreid 4096 Oct 27 23:32 en-us
-
-./en-us:
-total 40
-8 drwxrwxr-x 2 kathyreid kathyreid 4096 Oct 27 23:32 .
-8 drwxrwxr-x 3 kathyreid kathyreid 4096 Oct 27 23:32 ..
-8 -rw-rw-r-- 1 kathyreid kathyreid   32 Oct 27 23:32 hello.world.dialog
-8 -rw-rw-r-- 1 kathyreid kathyreid   91 Oct 27 23:32 how.are.you.dialog
-8 -rw-rw-r-- 1 kathyreid kathyreid   88 Oct 27 23:32 welcome.dialog
+$ ls -l dialog
+total 4
+drwxr-xr-x 2 kris kris 4096 Oct  8 22:21 en-us
 ```
 
-There will be one file in the language subdirectory \(ie. `en-us`\) for each type of **dialog** the **Skill** will use. In the example above, there are three types of **dialog** used by the **Skill**. Let's take a look at a **dialog** file.
+#### Dialog Directory
+
+There will be one file in the language subdirectory \(ie. `en-us`\) for each type of dialog the Skill will use. Currently this will contain all of the phrases you input when creating the Skill.
 
 ```bash
-$ cat hello.world.dialog
-Hello world
-Hello
-Hi to you too
+$ ls -l dialog/en-us
+total 4
+-rw-r--r-- 1 kris kris 10 Oct  8 22:21 first.dialog
 ```
 
-You will notice that each line of **dialog** is slightly different. When instructed to use a particular **dialog**, Mycroft will chose one of these lines at random. This is closer to natural speech. That is, many similar phrases mean the same thing.
+When instructed to use a particular dialog, Mycroft will choose one of these lines at random. This is closer to natural speech. That is, many similar phrases mean the same thing.
 
 For example, how do you say 'goodbye' to someone?
 
@@ -140,391 +100,142 @@ For example, how do you say 'goodbye' to someone?
 * Goodbye
 * See ya!
 
-#### vocab directory and defining Intents
+#### Vocab Directory
 
-Each **Skill** defines one or more **Intents**. Intents are defined in the 'vocab' directory. The 'vocab' directory is organized by language, just like the 'dialog' directory.
+Each Skill defines one or more Intents. Intents are defined in the `vocab` directory. The `vocab` directory is organized by language, just like the `dialog` directory.
 
-In this example, we can see that there are three **Intents**, each defined in
+We will learn about Intents in more detail shortly. For now, we can see that within the `vocab` directory you may find multiple types of files:
+- `.intent` files used for defining Padatious Intents
+- `.voc` files define keywords primarily used in Adapt Intents
+- `.entity` files define a named entity also used in Adapt Intents
 
-'IntentKeyword.voc\`
-
-**vocab** files:
-
-```bash
-mycroft-skills/skill-hello-world/vocab/en-us$ ls -las
-total 40
-8 drwxrwxr-x 2 kathyreid kathyreid 4096 Nov  9 00:11 .
-8 drwxrwxr-x 3 kathyreid kathyreid 4096 Nov  9 00:11 ..
-8 -rw-rw-r-- 1 kathyreid kathyreid   22 Nov  9 00:11 HelloWorldKeyword.voc
-8 -rw-rw-r-- 1 kathyreid kathyreid   52 Nov  9 00:11 HowAreYouKeyword.voc
-8 -rw-rw-r-- 1 kathyreid kathyreid   17 Nov  9 00:11 ThankYouKeyword.voc
-```
-
-Just like **dialog** files, **vocab** files can have multiple lines. Mycroft will match _any_ of these phrases with the **Intent**. If we have a look at the
-
-`ThankYouKeyword.voc`
-
-file, we can see this in action:
+In our current example we might see something like:
 
 ```bash
-$ cat ThankYouKeyword.voc
-thank you
-thanks
+$ ls -l vocab/en-us
+total 4
+-rw-r--r-- 1 kris kris 23 Oct  8 22:21 first.intent
 ```
 
-If the User speaks _either_
+This `.intent` file will contain all of the sample utterances we provided when creating the Skill.  
 
-> thank you
+#### Locale Directory
+This directory is a newer addition to Mycroft and combines `dialog` and `vocab` into a single directory. This was requested by the Community to reduce the complexity of a Skills structure, particularly for smaller Skills. Any of the standard file types that we've looked at so far will be treated the same if they are contained in the `dialog`, `vocab`, or `locale` directories.
 
-or
+This also includes the `regex` directory that you will learn about later in the tutorial.
 
-> thanks
+### \_\_init\_\_.py
 
-Mycroft will match this to the
-
-`ThankYou`
-
-**intent** in the **Skill**.
-
-_NOTE: One of the most common mistakes when getting started with **Skills** is that the **vocab** file doesn't include all the phrases that the User might use to trigger the **intent**._
-
-#### **init**.py
-
-`__init__.py`
-
-is where most of the **Skill** is defined, using Python code.
+The `__init__.py` file is where most of the Skill is defined using Python code. We will learn more about the contents of this file in the next section.
 
 Let's take a look:
 
+#### Importing libraries
+
 ```python
 from adapt.intent import IntentBuilder
-from mycroft import MycroftSkill
-from mycroft.util.log import getLogger
+from mycroft import MycroftSkill, intent_file_handler, intent_handler
 ```
 
-This section of code imports the required _libraries_. These libraries will be required on every **Skill**. Your skill may need to import additional libraries.
+This section of code imports the required _libraries_. Some libraries will be required on every Skill, and your skill may need to import additional libraries.
 
-The
+#### Class definition
 
-`class`
-
-definition extends the
-
-`MycroftSkill`
-
-class:
+The `class` definition extends the `MycroftSkill` class:
 
 ```python
 class HelloWorldSkill(MycroftSkill):
 ```
 
-The class should be named logically, for example "TimeSkill", "WeatherSkill", "NewsSkill", "IPaddressSkill". If you would like guidance on what to call your **Skill**, please join the [~skills Channel on Mycroft Chat](https://chat.mycroft.ai/community/channels/skills).
+The class should be named logically, for example "TimeSkill", "WeatherSkill", "NewsSkill", "IPaddressSkill". If you would like guidance on what to call your Skill, please join the [~skills Channel on Mycroft Chat](https://chat.mycroft.ai/community/channels/skills).
 
 Inside the class, methods are then defined.
 
-```python
-def __init__(self):
-        super(HelloWorldSkill, self).__init__(name="HelloWorldSkill")
-```
+#### \_\_init\_\_\(\)
 
-This method is the _constructor_, and the key function it has is to define the name of the **Skill**.
+This method is the _constructor_. It is called when the Skill is first constructed. It is often used to declare state variables or perform setup actions, however it cannot utilise MycroftSkill methods as the class does not yet exist. You don't have to include the constructor.
 
-_NOTE: You don't have to include the constructor unless you plan to declare state variables for the Skill object. If you plan to declare state variables, then they should be defined in this block. If you don't include the constructor, the name of the **Skill** will be taken from the name of the `class`, in this case 'HelloWorldSkill'._
-
-Example:
+An example `__init__` method might be:
 
 ```python
 def __init__(self):
-        super(HelloWorldSkill, self).__init__(name="HelloWorldSkill")
-        self.already_said_hello = False
-        self.be_friendly = True
-        self.hello_phrases = ['Hello', 'Hallå', 'Olá']
+    super().__init__()
+    self.already_said_hello = False
+    self.be_friendly = True
 ```
+
+#### initialize\(\)
+
+Perform any final setup needed for the skill here. This function is invoked after the skill is fully constructed and registered with the system. Intents will be registered and Skill settings will be available.
 
 ```python
 def initialize(self):
-        thank_you_intent = IntentBuilder("ThankYouIntent").
-            require("ThankYouKeyword").build()
-        self.register_intent(thank_you_intent, self.handle_thank_you_intent)
-
-        how_are_you_intent = IntentBuilder("HowAreYouIntent").
-            require("HowAreYouKeyword").build()
-        self.register_intent(how_are_you_intent,
-                             self.handle_how_are_you_intent)
-
-        hello_world_intent = IntentBuilder("HelloWorldIntent").
-            require("HelloWorldKeyword").build()
-        self.register_intent(hello_world_intent,
-                             self.handle_hello_world_intent)
+    my_setting = self.settings.get('my_setting')
 ```
 
-The
 
-`initialize()`
+#### Intent handlers
 
-function defines each of the **Intents** of the **Skill**. Note that there are three **Intents** defined in
+Previously the `initialize` function was used to register intents, however our new `@intent_handler` and `@intent_file_handler` decorators are a cleaner way to achieve this. We will learn all about the different [Intents](intents.md) shortly.
 
-`initialize()`
-
-, and there were three **Intents** defined in **vocab** files.
-
-Next, there are methods that handle each of the **Intents**.
-
+In our current HelloWorldSkill we can see two different styles.
+1. An Adapt handler, triggered by a keyword defined in a `ThankYouKeyword.voc` file.
 ```python
-def handle_hello_world_intent(self, message):
-        self.speak_dialog("hello.world")
+@intent_handler(IntentBuilder('ThankYouIntent').require('ThankYouKeyword'))
+def handle_thank_you_intent(self, message):
+    self.speak_dialog("welcome")
 ```
 
-In the
+2. A Padatious intent handler, triggered using a list of sample phrases.
+```python
+@intent_file_handler('HowAreYou.intent')
+def handle_how_are_you_intent(self, message):
+    self.speak_dialog("how.are.you")
+```
 
-`handle_hello_world_intent()`
+In both cases, the function receives two _parameters_:
+* `self` - a reference to the HelloWorldSkill object itself
+* `message` - an incoming message from the `messagebus`.
 
-method above, the method receives two _parameters_,
+Both intents call the `self.speak_dialog()` method, passing the name of a dialog file to it. In this case `welcome.dialog` and `how.are.you.dialog`.
 
-`self`
+#### stop\(\)
+You will usually also have a `stop()` method.
 
-and
-
-`message`
-
-`self` is the reference to the object itself, and `message` is an incoming message from the `messagebus`. This method then calls the
-
-`speak_dialog()`
-
-method, passing to it the
-
-`hello.world`
-
-dialog. Remember, this is defined in the file "hello.world.dialog".
-
-Can you guess what Mycroft will Speak?
-
-You will usually also have a
-
-`stop()`
-
-method. This method tells Mycroft what to do if a stop **intent** is detected.
+This tells Mycroft what your Skill should do if a stop intent is detected.
 
 ```python
 def stop(self):
     pass
 ```
 
-In the above code block, the [`pass` statement](https://docs.python.org/2/reference/simple_stmts.html#the-pass-statement) is used as a placeholder; it doesn't actually have any function. However, if the **Skill** had any active functionality, the stop\(\) method would terminate the functionality, leaving the _Skill\*_ in a known good state.
+In the above code block, the [`pass` statement](https://docs.python.org/3/reference/simple_stmts.html#the-pass-statement) is used as a placeholder; it doesn't actually have any function. However, if the Skill had any active functionality, the stop\(\) method would terminate the functionality, leaving the Skill in a known good state.
 
-#### Intents and regular expressions \(regex\)
+#### create_skill\(\)
 
-In the examples above, we walked through how to use phrases in a `.voc` file to build an `Intent` using _entities_. In this section, we expand on how `Intents` are built, and introduce _multiple entities_, and _regular expressions_.
-
-Throughout this section, we will be using examples from the [Date and Time Skill](https://github.com/MycroftAI/skill-date-time).
-
-**How .voc files are used to handle Intents**
-
-At the top of your **Skill** file, you will have a line that looks like this:
-
-`from adapt.intent import IntentBuilder`
-
-This tells your **Skill** to import the `IntentBuilder` class from Adapt. Adapt is an Intent-handling engine. Its job is to understand what a user Speaks to Mycroft, and to pass that information to a **Skill** for handling.
-
-Different **Skills** require different information from the user. For example, the **Skill** to change the color of Mycroft's eyes just has one parameter - `color`. That parameter is mandatory - because you can't change the color of Mycroft's eyes without knowing what color to change them to.
-
-Later in your **Skill** file, you will call `IntentBuilder`, with one or more parameters. The parameters can be either `required` or `optional`.
-
-For example, here is the `@intent_handler` _decorator_ used in the [Date and Time Skill](https://github.com/MycroftAI/skill-date-time). It has three parameters; two are `required` and one is `optional`.
+The final code block in our Skill is the `create_skill` function that returns our new Skill:
 
 ```python
-@intent_handler(IntentBuilder("")
-  .require("Query")
-  .require("Time")
-  .optionally("Location")
-)
+def create_skill():
+    return HelloWorldSkill()
 ```
 
-This call is then interpreted by the Adapt Intent Parser.
+This is required by Mycroft and is responsible for actually creating an instance of your Skill that Mycroft can load.
 
-Internally, Adapt uses a function called `register_entity`, and tries to register `entities` based on the parameters passed to `IntentBuilder`. There are several ways that Adapt can register `entities`.
+_Please note that this function is not scoped within your Skills class. It should not be indented to the same level as the methods discussed above._
 
-If we were building `Intent`s manually, we would do something like this:
+### LICENSE
+This file contains the full text of the license your Skill is being distributed under. It is not required for the Skill to work, however all Skills submitted to the [Marketplace](https://market.mycroft.ai) must be released under an appropriate open source license.
 
-```python
-locations = [
-    "Seattle",
-    "San Francisco",
-    "Tokyo"
-]
+### README.md
+The README file contains human readable information about your Skill. The information in this file is used to generate the Skills entry in the [Marketplace](https://market.mycroft.ai). More information about this file, can be found in the [Marketplace Submission section](marketplace-submission/skill-readme-md.md).
 
-for loc in locations:
-    engine.register_entity(loc, "Location")
-```
+### settingsmeta.yaml
+This file defines the settings that will be available to a User through their account on [Home.Mycroft.ai](https://home.mycroft.ai/skills).
 
-But what if we want to support more `locations`? Or make the `location` available to the **Skill** to use as a parameter in an API call?
+Jump to [Skill Settings](next-steps/skill-settings.md) for more information on this file and handling of Skill settings.
 
-First, Adapt will look in `.voc` files to try and register an `Intent`. For example, in the [Date and Time Skill](https://github.com/MycroftAI/skill-date-time), in the `vocab` directory, you will see several `.voc` files. Note that they each correspond to one of the parameters passed to `Intentbuilder()`.
 
-```bash
-pi@mark_1:/opt/mycroft/skills/skill-date-time/vocab/en-us $ ls -las
-total 24
-4 drwxr-xr-x 2 mycroft mycroft 4096 Feb 15 14:17 .
-4 drwxr-xr-x 4 mycroft mycroft 4096 Feb 15 14:17 ..
-4 -rwxr-xr-x 1 mycroft mycroft    8 Feb 15 14:17 Date.voc
-4 -rwxr-xr-x 1 mycroft mycroft   12 Feb 15 14:17 Display.voc
-4 -rwxr-xr-x 1 mycroft mycroft    9 Feb 15 14:17 Query.voc
-4 -rwxr-xr-x 1 mycroft mycroft    5 Feb 15 14:17 Time.voc
-```
+## What have we learned
 
-If we take a look inside each of these files, they contain only a single word each:
-
-* `Date.voc` =&gt; "date"
-* \`Display.voc =&gt; "display"
-* `Query.voc`=&gt; "what"
-* `Time.voc` =&gt; "time"
-
-Now, remember back to `IntentBuilder` and the mandatory and optional parameters? Only `Query` and `Time` were mandatory. So if a user Spoke:
-
-`"Hey Mycroft, **what** **time** is it?"`
-
-then Adapt would match that **Utterance** to the [Date and Time Skill](https://github.com/MycroftAI/skill-date-time), by _registering_ the `Intent`, and within the **Skill**, this would be handled by the `handle_query_time()` function.
-
-If the user Spoke:
-
-`"Hey Mycroft, **display** the **time** "`
-
-which function within the Date and Time Skill do you think would handle the **Utterance**?
-
-_ANSWER: handle\_show\_time\(\)_
-
-But what about `Location`? There isn't a `.voc` file for `Location`, so how does Adapt register an `entity` for `Location` so that `Location` can be included in an **Utterance**, recognised as an `Intent`, and handled properly by the [Date and Time Skill](https://github.com/MycroftAI/skill-date-time)?
-
-This is done using [regular expressions](https://docs.python.org/2/library/re.html).
-
-In the [Date and Time Skill](https://github.com/MycroftAI/skill-date-time) directory, you will see a sub-directory called `regex`. This sub-directory follows the same file structure as the `voc` directory \(eg. there will be an `en-us` directory inside\), and contains a file called 'location.rx':
-
-```bash
-pi@mark_1:/opt/mycroft/skills/skill-date-time/regex/en-us $ ls -las
-total 12
-4 drwxr-xr-x 2 mycroft mycroft 4096 Feb 15 14:17 .
-4 drwxr-xr-x 4 mycroft mycroft 4096 Feb 15 14:17 ..
-4 -rwxr-xr-x 1 mycroft mycroft   28 Feb 15 14:17 location.rx
-```
-
-Inside `location.rx` is a _regular expression_:
-
-`(at|in|for) (?P<Location>.*)`
-
-Because a `.voc` file is not present for the `Location` parameter, Adapt will then search for an equivalent `.rx` file in the `regex` directory. Instead of being restricted to the specified words in the `.voc` file, Adapt can register `Intents` using _regular expressions_, and thus support a wider range of input from the user.
-
-Can you think of another **Skill** where a _regular expression_ `Location` would be useful?
-
-_ANSWER:_ [_Weather Skill_](https://github.com/MycroftAI/skill-weather)
-
-For those who are new to Python, the `regex` used is a [Python named _group_](https://docs.python.org/2/library/re.html#regular-expression-syntax). The name of the group is case-sensitive, and correlates with the variable name used to extract the named group value.
-
-For example, in the [Date and Time Skill](https://github.com/MycroftAI/skill-date-time), we can see one of the functions uses `Location` as an optional parameter to the function.
-
-[Link to the code snipped below](https://github.com/MycroftAI/skill-date-time/blob/master/__init__.py#L257%20)
-
-```python
-@intent_handler(IntentBuilder("").require("Query").require("Time").
-                    optionally("Location"))
-    def handle_query_time(self, message):
-        location = message.data.get("Location")
-        current_time = self.get_spoken_time(location)
-        if not current_time:
-```
-
-The `Location` value is extracted by calling `message.data.get("Location")`. If the named group was named differently, such as `TheUserLocation`, then this code would look like:
-
-```python
-@intent_handler(IntentBuilder("").require("Query").require("Time").
-                    optionally("TheUserLocation"))
-    def handle_query_time(self, message):
-        location = message.data.get("TheUserLocation")
-        current_time = self.get_spoken_time(location)
-        if not current_time:
-```
-
-## Simplifying your Skill code with `intent_handler` _decorators_
-
-Your **Skill** code can be simplified using the intent_handler\(\) \_decorator_. The major advantage in this approach is that the **Intent** is described together with the method that handles the **Intent**. This makes your code easier to read, easier to write, and errors will be easier to identify.
-
-[Learn more about what _decorators_ are in Python at this link](https://en.wikipedia.org/wiki/Python_syntax_and_semantics#Decorators).
-
-The intent_handler\(\) \_decorator_ tags a method to be an intent handler for the intent, removing the need for separate registration.
-
-First, you need to `import` the `intent_handler()` library. Include the following line in the `import` section:
-
-```text
-from mycroft import intent_handler
-```
-
-Then, you will be able to use the `@intent_handler` _decorator_:
-
-```python
-    @intent_handler(IntentBuilder('IntentName').require('Keyword'))
-    def handler_method(self):
-        # [...]
-```
-
-Using these _decorators_ the **Skill** becomes:
-
-```python
-class HelloWorldSkill(MycroftSkill):
-    def __init__(self):
-        super(HelloWorldSkill, self).__init__(name="HelloWorldSkill")
-
-    @intent_handler(IntentBuilder("ThankYouIntent").require("ThankYouKeyword"))
-    def handle_thank_you_intent(self, message):
-        self.speak_dialog("welcome")
-
-    @intent_handler(IntentBuilder("HowAreYouIntent")
-                    .require("HowAreYouKeyword"))
-    def handle_how_are_you_intent(self, message):
-        self.speak_dialog("how.are.you")
-
-    @intent_handler(IntentBuilder("HelloWorldIntent")
-                    .require("HelloWorldKeyword"))
-    def handle_hello_world_intent(self, message):
-        self.speak_dialog("hello.world")
-
-    def stop(self):
-        pass
-```
-
-As seen above the entire initialize\(\) method is removed and the **Intent** registration is moved to the the method declaration.
-
-Ideally, you should use approach to **Intent** registration.
-
-## How do I disable a Skill?
-
-During Skill development you may have reason to disable one or more **Skills**. Rather than constantly install or uninstall them via voice, or by adding and removing them from `/opt/mycroft/skills/`, you can disable them in [the `mycroft.conf` file](https://mycroft.ai/documentation/mycroft-conf/).
-
-First, identify the name of the **Skill**. The name of the **Skill** is the `path` attribute in the [`.gitmodules`](https://github.com/MycroftAI/mycroft-skills/blob/master/.gitmodules) file.
-
-To disable one or more **Skills** on a Mycroft **Device**, find where your `mycroft.conf` file is stored, then edit it using an editor like `nano` or `vi`.
-
-Search for the string `blacklisted` in the file. Then, edit the line below to include the **Skill** you wish to disable, and save the file. You will then need to reboot, or restart the `mycroft` services on the **Device**.
-
-```text
-  "skills": {
-    "blacklisted_skills": ["skill-media", "send_sms", "skill-wolfram-alpha, YOUR_SKILL"]
-  }
-```
-
-## How to increase the priority of **Skills** during loading
-
-During **Skill** development, you may wish to increase the priority of your **Skill** loading during the startup process. This allows you to start using the **Skill** as soon as possible.
-
-First, identify the name of the **Skill**. The name of the **Skill** is the `path` attribute in the [`.gitmodules`](https://github.com/MycroftAI/mycroft-skills/blob/master/.gitmodules) file.
-
-To prioritize loading one or more **Skills** on a Mycroft **Device**, find where your [`mycroft.conf` file](https://mycroft.ai/documentation/mycroft-conf/) is stored, then edit it using an editor like `nano` or `vi`.
-
-Search for the string `priority` in the file. Then, edit the line below to include the **Skill** you wish to prioritize, and save the file. You will then need to reboot, or restart the `mycroft` services on the **Device**.
-
-```text
-"priority_skills": ["skill-pairing"],
-```
-
-## How do I find more information on Mycroft functions?
-
-You can find documentation on Mycroft functions and helper methods at the [Mycroft Core API documentation](https://mycroft-core.readthedocs.io/en/master/)
-
+You have no successfully created a new Skill and have an understanding of the basic components that make up a Mycroft Skill. Next we will dive into each component in more detail.


### PR DESCRIPTION
Large rewrite of the Intro to Skill Development and Your First Skill pages to reflect the latest suggested practices when developing Skills. Strongly encourage people to use `MSK create` rather than forking the template skill.