### PR TITLE
Clean up converse() code

### DIFF
--- a/docs/skill-development/introduction/lifecycle-methods.md
+++ b/docs/skill-development/introduction/lifecycle-methods.md
@@ -49,12 +49,11 @@ If the utterance is handled by the converse method, we return `True` to indicate
 In the following example, we check that utterances is not empty, and if the utterance matches vocabulary from `understood.voc`. If the user has understood we speak a line from `great.dialog` and return `True` to indicate the utterance has been handled. If the vocabulary does not match then we return `False` as the utterance should be passed to the normal intent matching service.
 
 ```text
-    def converse(self, utterances, lang):
+    def converse(self, utterances, lang=None):
         if utterances and self.voc_match(utterances[0], 'understood'):
             self.speak_dialog('great')
             return True
-        else:
-            return False
+        return False
 ```
 
 ## Stop


### PR DESCRIPTION
The method signature was different from the parent class, and the `else:` block was redundant.

As an aside, I'm a new skill developer and this documentation has created more questions than answers for me.  From what I'm reading here, all I should need to do is add a `converse()` method and it'll be triggered before the intent handler... except in my experience it's not triggered at all.