### PR TITLE
TTS Config for IBM Watson

### DIFF
--- a/docs/using-mycroft-ai/customizations/tts-engine.md
+++ b/docs/using-mycroft-ai/customizations/tts-engine.md
@@ -109,6 +109,8 @@ mycroft-config set tts.module "google"
 
 ### Account Setup
 Create an account at [IBM.com/cloud](https://www.ibm.com/cloud/watson-text-to-speech).
+You can find a list of available voices at [Languages and Voices](https://cloud.ibm.com/docs/text-to-speech?topic=text-to-speech-voices#neuralVoices). For example, "en-US_MichaelV3Voice". Please note that IBM keeps a log of all requests in the lite plan unless you turn it explicitly.
+
 
 ### Mycroft Configuration
 Using the [Configuration Manager](config-manager.md) we can edit the `mycroft.conf` file by running:
@@ -121,6 +123,7 @@ To our existing configuration values we will add the following:
 "tts": {
   "module": "watson",
   "watson": {
+    "voice":"PREFERRED_VOICE",
     "api_key": "YOUR_API_KEY",
     "username": "YOUR_USERNAME", # Not needed if api_key is set
     "password": "YOUR_PASSWORD"  # Not needed if api_key is set


### PR DESCRIPTION
IBM Watson TTS does not produce any output unless a voice is specified.