### PR TITLE
Initial Plugins writeup.

### DIFF
--- a/docs/mycroft-technologies/mycroft-core/plugins/README.md
+++ b/docs/mycroft-technologies/mycroft-core/plugins/README.md
@@ -1,0 +1,66 @@
+---
+description: >-
+Mycroft plugins allows developers to create and distribute new features for 
+some of mycroft's main systems.
+---
+
+## Mycroft plugins
+
+The plugins extend Mycroft, adding support for new Speech engines, software to play media files, etc.. The idea is that the community shall be able to build and publish plugins extending Mycroft and adding support for new things without the need to bundle the code inside Mycroft-core. This gives the creator freedom to make updates in their own pace without needing to wait for a Mycroft core developer to verify their code contribution (and then wait for the next release).
+
+### Pluggable systems
+
+The plugins are normal pip-installable python modules specifying specially named "entry points". The entry points are a python packaging mechanism for creating common api's and making them discoverable. For more info see the [Python Packaging Guide](https://packaging.python.org/guides/creating-and-discovering-plugins/)
+
+Mycroft supports plugins for
+
+- [Speech to Text (STT)](stt.md)
+- [Text to Speech (TTS)](tts.md)
+- [Audioservice backends](audioservice.md)
+
+Entry point types
+ - TTS Plugin: `mycroft.plugin.tts`
+ - STT Plugin: `mycroft.plugin.stt`
+ - Audioservice Plugin `mycroft.plugin.audioservice`
+
+### Plugin setup.py
+
+A pip installable package always contain a setup.py file with install instructions, this will not be described in detail on this page but python-packaging has a [great guide](https://python-packaging.readthedocs.io/en/latest/).
+
+To make a plugin discoverable an `entry_point` must be added to the setup call in setup.py
+
+```python
+entry_ponts={'entrypoint type': 'my_plugin_name' = 'my_module.myPluginClass'
+```
+`my_plugin_name` will be the module identifier that can be used in the configuration to reference a plugin, and that will refer to the class (or module) specified by the string to the right of the equal sign. In the example above it will refer to the `myPluginClass` in the module `my_module`
+
+A complete setup.py example:
+
+```python
+#!/usr/bin/env python3
+from setuptools import setup
+
+PLUGIN_ENTRY_POINT = 'example_plug = mycroft_example_plugin:ExamplePlugin'
+setup(
+    name='mycroft-example-plugin',
+    version='1',
+    description='A tts plugin for mycroft',
+    author='Mike Roft',
+    author_email='mike@email.com',
+    packages=['mycroft_example_plugin'],
+    keywords='mycroft plugin tts',
+    entry_points={'mycroft.plugin.tts': PLUGIN_ENTRY_POINT}
+)
+```
+
+This will add a tts module called *example_plug* which will refer to a TTS class called `ExamplePlugin` in the module `mycroft_example_plugin`.
+
+In the config this will be selected by setting the tts module to `example_plug`.
+
+```json
+  "tts": {
+    "module": "example_plug"
+  }
+```
+
+A complete example plugin re-implementing google TTS can be found [here](https://github.com/forslund/mycroft-tts-plugin-gtts) and a template for creating the setup.py can be found [here](https://gist.github.com/forslund/8e51cba0ffd4e671dfc188e4e33fdbd7).

--- a/docs/mycroft-technologies/mycroft-core/plugins/audioservice.md
+++ b/docs/mycroft-technologies/mycroft-core/plugins/audioservice.md
@@ -1,0 +1,53 @@
+---
+Description: Audioservice Backend  plugins handles playing and queuing audio files.
+---
+# Audioservice Backend plugin
+
+An audio service adds an interface to a media player allowing Mycroft to play new types of media files or on remote devices.
+
+## AudioBackend
+The audioservice creator needs implement a class derived from `AudioBackend` found in `mycroft.audio.service`. This class implements all basic commands and will be called by mycroft. For complete specification see the [docstrings](https://github.com/MycroftAI/mycroft-core/blob/dev/mycroft/audio/services/__init__.py) for the class.
+
+Apart from all the play / pause / etc. commands it's there are a couple of important methods to mention.
+
+The `supported_uris()` method this is used to deterine if the service backend can handle the given uri-type (https://, file://, etc). A basic implementation will return an iterable with uri types: `('file', 'http', 'https')`
+
+The playlist handling methods `clear_list()` and `add_list()`, of which the first removes all items from the current list and the second _appends_ a list of uri's to the list.
+
+### RemoteAudioBackend
+
+If the audio backend that's implemented plays media on another device than the one Mycroft is running on this base class should be used. it's mainly used to sort generic playback queries defaulting to a local audio backend unless otherwise specified.
+
+## Instantiation
+
+An audioservice can instanciate a number of backend objects so an instanciation function called `load_service()` needs to exist in the module. It will be called with the mycroft audio configuration and a connection to the messagebus. The method should return an tuple with audio backends included in the file.
+
+The basic layout of a plugin will be something like
+
+```python
+from mycroft.audio.service import AudioBackend
+
+class MyAudioBackend(AudioBackend)
+    #lots of implementation here
+    [...]
+
+
+def load_service(config, bus):
+    return (MyAudioBackend(config, bus), )
+```
+
+The `load_service()` function can also be used to scan the local network for things like chromecasts and create an audioservice backend for each found device.
+
+### Entry point
+
+To make the audioservice detectable as an Audioserice backend plugin, the package needs to provide an entry point under the `mycroft.plugin.audioservice` namespace.
+
+```python
+setup([...],
+      entry_points = {'mycroft.plugin.audioservice': 'example_audiobackend = my_audiobackend'}
+      )
+```
+
+Where `example_audiobackend` is is the audio service module name for the plugin, my_audiobackend will be the audioservice module containing the `load_service()`function.
+
+Note that this differs a fair bit from the TTS and STT which points to a single class.

--- a/docs/mycroft-technologies/mycroft-core/plugins/stt.md
+++ b/docs/mycroft-technologies/mycroft-core/plugins/stt.md
@@ -1,0 +1,65 @@
+---
+Description: STT plugins handles converting Speech to Text
+---
+# Speech To Text plugin
+
+All Mycroft Speech to Text plugins need to provide a class derived from the STT base class in `mycroft.stt`
+
+When the `__init__()` method of the base class is run the config for it will be loaded, and available through `self.config` Mycroft's selected language will also be available through `self.lang`
+
+So for example
+
+```json
+  "stt": {
+    "module": "example_stt"
+    "example_stt": {
+      "server": "https://my_server.com",
+      "samplerate": 16000
+    }
+  }
+```
+
+will load the the `"example_stt"` structure from the `"stt"` section and provide that in `self.config`.
+
+### execute()
+
+The STT plugin class needs to define the execute() method taking audio as an argument with lang as an optional parameter (currently not used in core.
+
+The audio argument is an [AudioData](https://github.com/Uberi/speech_recognition/blob/master/reference/library-reference.rst#audiodataframe_data-bytes-sample_rate-int-sample_width-int---audiodata) object.
+
+The bare minimum STT class will look something like
+
+```python
+
+class MySTT(STT):
+    def execute(audio, language=None):
+        # Handle audio data and return transcribed text
+        [...]
+        return text
+```
+
+### STT base class
+
+The stt system has a couple of base classes specified,
+
+#### `STT`
+
+The base STT, this handles the audio in "batch mode" taking a complete sentence in the audio, and from it generates speech.
+
+#### `StreamingSTT`
+
+A more advanced STT class for streaming data to the STT. This will recieve chunks of audio data as they become available and streaming them to an STT engine.
+
+The plugin author needs to implement the `create_streaming_thread()` method creating a thread for handling data sent through `self.queue`. The thread this method creates should be based on the [StreamThread class](https://github.com/MycroftAI/mycroft-core/blob/dev/mycroft/stt/__init__.py#L325) and `handle_audio_data()` method needs to be implemented.
+
+### Entry point
+
+To make the class detectable as an STT plugin, the package needs to provide an entry point under the `mycroft.plugin.stt` namespace.
+
+```python
+setup([...],
+      entry_points = {'mycroft.plugin.stt': 'example_stt = my_stt:mySTT'}
+      )
+```
+
+Where `example_stt` is is the STT module name for the plugin, my_stt is the python module and mySTT is the class in the module to return.

--- a/docs/mycroft-technologies/mycroft-core/plugins/tts.md
+++ b/docs/mycroft-technologies/mycroft-core/plugins/tts.md
@@ -1,0 +1,81 @@
+---
+Description: TTS plugins handles converting Text to Speech
+---
+## Creating a Mycroft TTS
+
+All mycroft TTS plugins need to define a class based on the TTS base class from mycroft.tts
+
+```python
+from mycroft.tts import TTS
+
+class myTTS(TTS):
+    def __init__(self, lang, config):
+        super().__init__(lang, config, validator, audio_ext='wav',
+                         phonetic_spelling=False, ssml_tags=None)
+        # Any specific init code goes here
+
+```
+
+The `super()` call does some setup adding specific options to how mycroft will preprocess the sentence.
+
+- `audio_ext`: filetype of output, possible options 'wav' and 'mp3'
+- `phonetec_spelling`, True if Mycroft should preprocess some difficult to pronounce words (ex spotify) or provide the raw text to the tts.
+- `ssml_tags`: list of valid SSML tags for the TTS if any, otherwise None
+- validator a special class that verifies that the TTS is working in the current configuration.
+
+It also regisers the module's config from the mycroft configuration in `self.config` as well as the current language in `self.lang`
+
+For the following config snippet
+
+```json
+  "tts": {
+    "module": "example_tts",
+    "example_tts": {
+      ...
+    }
+  }
+```
+
+Mycroft will register the `"example_tts"` part in the TTS's `self.config`
+
+### `get_tts()`
+
+The `get_tts()` method will be called by Mycroft to generate audio and (optionally) phonemes. This is the main method that the plugin creator needs to implement.
+
+It's called with a `sentence`, a piece of text to turn into audio, and a `wav_file` an path to where Mycroft would like to store the generated audio data.
+
+This method should generate audio data and return a Tuple (path to written data (generally the input argument), phoneme list).
+
+As an example see the [get_tts for mimic2](https://github.com/MycroftAI/mycroft-core/blob/dev/mycroft/tts/mimic2_tts.py#L225)
+
+### TTS Validator
+
+To check if the TTS can be used a validator class is needed, this should inherit from `mycroft.tts.TTSValidaor`. It will be called with the TTS class as argument and will store it in `self.tts`.
+
+The following is the bare minimum implementation:
+
+```python
+class MyValidator(TTSValidator):
+    def get_tts_class(self):
+        # Should return a reference to the TTS class it's inteded to validate.
+
+    def validate_lang(self):
+        # Raise exception if `self.tts.lang` is not supported.
+
+    def validate_connection(self):
+        # Check that the software needed for the TTS is reachable,
+        # be it a local executable, python module or remote server and
+        # if not available raise an exception.
+```
+
+### Entry point
+
+To make the class detectable as an TTS plugin, the package needs to provide an entry point under the `mycroft.plugin.tts` namespace.
+
+```python
+setup([...],
+      entry_points = {'mycroft.plugin.tts': 'example_tts = my_tts:myTTS'}
+      )
+```
+
+Where example_tts is is the TTS module name for the plugin, my_tts is the python module and myTTS is the class in the module to return.


### PR DESCRIPTION
Adds information on how a module is created to be detected as a Mycroft plugin (as proposed in [mycroft-core PR #2594](https://github.com/MycroftAI/mycroft-core/pull/2594) and some basic instructions on how to create the different kind of plugins.

This is all quite brief still but is hopefully a good enough base to build on.