### PR TITLE
Update to use XDG locations everywhere

### DIFF
--- a/docs/mycroft-technologies/mycroft-skills-kit.md
+++ b/docs/mycroft-technologies/mycroft-skills-kit.md
@@ -58,18 +58,18 @@ The normal commands for `msk` are:
 
 ```bash
 msk create
-msk create-test /opt/mycroft/skills/myskill
-msk upload /opt/mycroft/skills/myskill
-msk upgrade /opt/mycroft/skills/myskill
+msk create-test $HOME/.local/share/mycroft/skills/myskill
+msk upload $HOME/.local/share/mycroft/skills/myskill
+msk upgrade $HOME/.local/share/mycroft/skills/myskill
 ```
 
 If using the built-in installation of `msk` with a Mycroft device or Mycroft git installation, use `mycroft-msk` in place of `msk`:
 
 ```bash
 mycroft-msk create
-mycroft-msk create-test /opt/mycroft/skills/myskill
-mycroft-msk upload /opt/mycroft/skills/myskill
-mycroft-msk upgrade /opt/mycroft/skills/myskill
+mycroft-msk create-test $HOME/.local/share/mycroft/skills/myskill
+mycroft-msk upload $HOME/.local/share/mycroft/skills/myskill
+mycroft-msk upgrade $HOME/.local/share/mycroft/skills/myskill
 ```
 
 ## Create
@@ -121,13 +121,13 @@ To https://github.com/YourGitHubUserName/feed-the-corgi-skill
  * [new branch]      master -> master
 Branch master set up to track remote branch master from origin.
 Created GitHub repo: https://github.com/YourGitHubUserName/feed-the-corgi-skill
-Created skill at: /opt/mycroft/skills/feed-the-corgi-skill
+Created skill at: $HOME/.local/share/mycroft/skills/feed-the-corgi-skill
 ```
 
-Now, if you look in `/opt/mycroft/skills/` you will see that all the files required for the **Skill** have now been created, including the `.voc` files.
+Now, if you look in `$HOME/.local/share/mycroft/skills/` you will see that all the files required for the **Skill** have now been created, including the `.voc` files.
 
 ```bash
-$ ls -las /opt/mycroft/skills/feed-the-corgi-skill
+$ ls -las $HOME/.local/share/mycroft/skills/feed-the-corgi-skill
 total 36
 4 drwxrwxr-x   5 kathyreid kathyreid 4096 Jun  7 05:20 .
 4 drwxr-xr-x 103 kathyreid kathyreid 4096 Jun  7 05:18 ..
@@ -141,7 +141,7 @@ total 36
 ```
 
 ```bash
-$ ls -las /opt/mycroft/skills/feed-the-corgi-skill/vocab/en-us/
+$ ls -las $HOME/.local/share/mycroft/skills/feed-the-corgi-skill/vocab/en-us/
 total 12
 4 drwxrwxr-x 2 kathyreid kathyreid 4096 Jun  7 05:20 .
 4 drwxrwxr-x 3 kathyreid kathyreid 4096 Jun  7 05:20 ..
@@ -163,7 +163,7 @@ As before if the mycroft-core github installation is used make sure to use `mycr
 Next, we use the `msk create-test` function. You _must_ pass the **Skill** directory location to the command, or it will fail.
 
 ```bash
-$ msk create-test /opt/mycroft/skills/feed-the-corgi-skill/
+$ msk create-test $HOME/.local/share/mycroft/skills/feed-the-corgi-skill/
 
 Which intent would you like to test?
 1. corgi.the.feed.intent
@@ -179,13 +179,13 @@ Choose expected dialog (leave empty to skip).
 1. corgi.the.feed
 
 > 1
-Generated test file: /opt/mycroft/skills/feed-the-corgi-skill/test/intent/corgi.the.feed.intent.0.intent.json
+Generated test file: $HOME/.local/share/mycroft/skills/feed-the-corgi-skill/test/intent/corgi.the.feed.intent.0.intent.json
 ```
 
 If we have a look inside the `corgi.the.feed.intent.0.intent.json` file we can see that the test has been created for us.
 
 ```javascript
-$ cat /opt/mycroft/skills/feed-the-corgi-skill/test/intent/corgi.the.feed.intent.0.intent.json
+$ cat $HOME/.local/share/mycroft/skills/feed-the-corgi-skill/test/intent/corgi.the.feed.intent.0.intent.json
 {
     "intent_type": "corgi.the.feed",
     "expected_dialog": "corgi.the.feed",
@@ -210,7 +210,7 @@ You will now see that your `bash` prompt is prefixed with `(venv)`.
 Next, we use the `msk upload` command with the path to the **Skill**:
 
 ```bash
-$ msk upload /opt/mycroft/skills/feed-the-corgi-skill/
+$ msk upload $HOME/.local/share/mycroft/skills/feed-the-corgi-skill/
 === GitHub Credentials ===
 Username: YourGitHubUserName
 Password:
@@ -238,10 +238,10 @@ Before you can use `msk upgrade`, you must ensure:
 * That your **Skill** has already been merged with the `mycroft-skills` repo.
 * That you have made changes to your **Skill** and that these changes have been committed to the **Skill's** `git` repository.
 
-Once your changes are committed, you can then use `msk upgrade` by passing the location of the Skill folder. Generally we find it's easiest to be inside the Skill's folder in `/opt/mycroft/skills/SKILL-NAME` and then use the current directory symbol, period `.`
+Once your changes are committed, you can then use `msk upgrade` by passing the location of the Skill folder. Generally we find it's easiest to be inside the Skill's folder in `$HOME/.local/share/mycroft/skills/SKILL-NAME` and then use the current directory symbol, period `.`
 
 ```text
-(.venv) kathyreid@kathyreid-Oryx-Pro:/opt/mycroft/skills/kathy-msk-test-skill$ msk upgrade .
+(.venv) kathyreid@kathyreid-Oryx-Pro:$HOME/.local/share/mycroft/skills/kathy-msk-test-skill$ msk upgrade .
 === GitHub Credentials ===
 Username: KathyReid
 Password:
@@ -275,16 +275,16 @@ Created PR at: https://github.com/MycroftAI/mycroft-skills/pull/661
 * If you try to run `msk upgrade` and your Skill has not yet been merged, you will receive the error:
 
 ```text
-(.venv) kathyreid@kathyreid-Oryx-Pro:/opt/mycroft/skills/kathy-msk-test-skill$ msk upgrade .
+(.venv) kathyreid@kathyreid-Oryx-Pro:$HOME/.local/share/mycroft/skills/kathy-msk-test-skill$ msk upgrade .
 NotUploaded: The skill kathy-msk-test-skill has not yet been uploaded to the skill store
 ```
 
 * If have uncommitted items, you will receive the error:
 
 ```text
-(.venv) kathyreid@kathyreid-Oryx-Pro:/opt/mycroft/skills/kathy-msk-test-skill$ msk upgrade .
+(.venv) kathyreid@kathyreid-Oryx-Pro:$HOME/.local/share/mycroft/skills/kathy-msk-test-skill$ msk upgrade .
 AlreadyUpdated: The latest version of kathy-msk-test-skill is already uploaded to the skill repo
-(.venv) kathyreid@kathyreid-Oryx-Pro:/opt/mycroft/skills/kathy-msk-test-skill$ git status
+(.venv) kathyreid@kathyreid-Oryx-Pro:$HOME/.local/share/mycroft/skills/kathy-msk-test-skill$ git status
 On branch master
 Your branch is up to date with 'origin/master'.
 
@@ -300,10 +300,10 @@ no changes added to commit (use "git add" and/or "git commit -a")
 You need to ensure that your changes are committed:
 
 ```text
-(.venv) kathyreid@kathyreid-Oryx-Pro:/opt/mycroft/skills/kathy-msk-test-skill$ git commit -a
+(.venv) kathyreid@kathyreid-Oryx-Pro:$HOME/.local/share/mycroft/skills/kathy-msk-test-skill$ git commit -a
 [master 6d0e355] test for msk
  1 file changed, 3 insertions(+)
-(.venv) kathyreid@kathyreid-Oryx-Pro:/opt/mycroft/skills/kathy-msk-test-skill$ git push -u origin master
+(.venv) kathyreid@kathyreid-Oryx-Pro:$HOME/.local/share/mycroft/skills/kathy-msk-test-skill$ git push -u origin master
 Username for 'https://github.com': KathyReid
 Password for 'https://KathyReid@github.com':
 Counting objects: 3, done.

--- a/docs/mycroft-technologies/mycroft-skills-manager.md
+++ b/docs/mycroft-technologies/mycroft-skills-manager.md
@@ -11,4 +11,3 @@ Mycroft Skills Manager \(MSM\) is a command line tool used to add, manage and re
 ## Using Mycroft Skills Manager
 
 See the Skill development section for general MSM usage instructions.
-

--- a/docs/skill-development/faq.md
+++ b/docs/skill-development/faq.md
@@ -2,7 +2,7 @@
 
 ## How do I disable a Skill?
 
-During Skill development you may have reason to disable one or more Skills. Rather than constantly install or uninstall them via voice, or by adding and removing them from `/opt/mycroft/skills/`, you can disable them in [the `mycroft.conf` file](https://mycroft.ai/documentation/mycroft-conf/).
+During Skill development you may have reason to disable one or more Skills. Rather than constantly install or uninstall them via voice, or by adding and removing them from `$HOME/.local/share/mycroft/skills/`, you can disable them in [the `mycroft.conf` file](https://mycroft.ai/documentation/mycroft-conf/).
 
 First, identify the name of the Skill. The name of the Skill is the `path` attribute in the [`.gitmodules`](https://github.com/MycroftAI/mycroft-skills/blob/master/.gitmodules) file.
 

--- a/docs/skill-development/introduction/your-first-skill.md
+++ b/docs/skill-development/introduction/your-first-skill.md
@@ -48,7 +48,7 @@ To create your first Skill, you will be asked for a:
 
 After inputting this data you will be asked if you would like a Github repo created for your Skill. This provides an easy way to store your Skill, and will be required if you choose to [publish your Skill in the Marketplace](../marketplace-submission/).
 
-If you have completed all of these steps, your Skill will have been created in the `/opt/mycroft/skills` directory on your device.
+If you have completed all of these steps, your Skill will have been created in the `$HOME/.local/share/mycroft/skills` directory on your device.
 
 In the next section, we will explore each component that makes up your Skill.
 

--- a/docs/skill-development/marketplace-submission/skills-acceptance-process/README.md
+++ b/docs/skill-development/marketplace-submission/skills-acceptance-process/README.md
@@ -34,19 +34,19 @@ Before submitting your Skill we assume you have:
 * Ensure any Python or other packages required to run your Skill are included in your requirements.txt or equivalent.
 * Run the [automated testing](../../voight-kampff/automatic-testing.md) on your own machine using the command:
 
-  `mycroft-skill-testrunner /opt/mycroft/skills/your-skill-directory`
+  `mycroft-skill-testrunner $HOME/.local/share/mycroft/skills/your-skill-directory`
 
 When you are satisfied your Skill is ready, submit it for formal review by running:
 
 ```text
-mycroft-msk submit /opt/mycroft/skills/your-skill-directory
+mycroft-msk submit $HOME/.local/share/mycroft/skills/your-skill-directory
 ```
 
 If you don't have the mycroft-msk command available, you can manually activate the Mycroft virtual environment and run `msk`
 
 ```text
 source ~/mycroft-core/.venv/bin/activate
-msk submit /opt/mycroft/skills/your-skill-directory
+msk submit $HOME/.local/share/mycroft/skills/your-skill-directory
 ```
 
 This will upload the Skill to Github if it isn’t already, and generate a pull request to add your Skill as a [Git submodule](https://gist.github.com/gitaarik/8735255) to the [Mycroft Skills Repo](https://github.com/MycroftAI/mycroft-skills).

--- a/docs/skill-development/skill-structure/dependencies/README.md
+++ b/docs/skill-development/skill-structure/dependencies/README.md
@@ -70,7 +70,7 @@ deactivate               # to exit the virtual environment again
 If you have already defined your Python package dependencies, you can use the `pip -r` flag to install all of these at once:
 
 ```bash
-cd /opt/mycroft/skills/my-skill
+cd $HOME/.local/share/mycroft/skills/my-skill
 mycroft-pip install -r requirements.txt
 ```
 

--- a/docs/skill-development/skill-structure/logging.md
+++ b/docs/skill-development/skill-structure/logging.md
@@ -87,7 +87,7 @@ except ZeroDivisionError as e:
 
 ## Where do these messages get logged?
 
-Log messages from a Skill are displayed in the Mycroft CLI so that a User can see in real-time what is happening in the Skill. They are also written to the `skills.log` file located at: `/var/opt/mycroft/skills.log`
+Log messages from a Skill are displayed in the Mycroft CLI so that a User can see in real-time what is happening in the Skill. They are also written to the `skills.log` file located at: `$HOME/.cache/mycroft/skills.log`
 
 By default all info, warning, error and exception level messages will be logged. Debug level messages will be logged if the User explicitly requests it. This can be done by issuing the `:log level debug` command in the CLI, or changing the `log_level` attribute in the [mycroft configuration](../../using-mycroft-ai/customizations/config-manager.md).
 

--- a/docs/skill-development/voight-kampff/README.md
+++ b/docs/skill-development/voight-kampff/README.md
@@ -41,6 +41,6 @@ When this specific test is run with the provided Steps, the system will: 1. Ensu
 Each `Feature` we define for our Skills test suite should be placed in it's own file inside the `test/behave` directory of our Skill. For this example we will save the Feature file in:
 
 ```text
-/opt/mycroft/skills/my-weather-skill/test/behave/current-weather.feature`
+$HOME/.local/share/mycroft/skills/my-weather-skill/test/behave/current-weather.feature`
 ```
 

--- a/docs/skill-development/voight-kampff/automatic-testing.md
+++ b/docs/skill-development/voight-kampff/automatic-testing.md
@@ -43,7 +43,7 @@ The most interesting files from a Skill Author's perspective are:
 
 The `runner.py` can be copied to the Skill Author's working directory, where the **Skill's** `__init__.py` file exists or invoked directly with the skill path as argument. Running `runner.py` will test only the **Skills** it finds in the directory it is in, or, if it can’t find a **Skill**, it will search any subdirectory.
 
-The `discover_test.py` is the Python file that runs integration tests on all **Skills** in `/opt/mycroft/skills`. It is intended for debugging that all your tests are found by the test runner.
+The `discover_test.py` is the Python file that runs integration tests on all **Skills** in `$HOME/.local/share/mycroft/skills`. It is intended for debugging that all your tests are found by the test runner.
 
 The `message_tester.py` is a utility that can test a single message against the internal rule format used by the `skill_tester`. It is intended for debugging rules.
 
@@ -241,7 +241,7 @@ Each message event is tested by the rules. When all rules have succeeded, the te
 Test case output file:
 
 ```text
-/opt/mycroft/skills/skill-pairing/test/intent/sample1.intent.json
+$HOME/.local/share/mycroft/skills/skill-pairing/test/intent/sample1.intent.json
 Test case: {u'intent': {u'DevicePairingPhrase': u'pair my device'}, u'intent_type': u'PairingIntent', u'utterance': u"let's pair my device"}
 Rule created [['and', ['endsWith', 'intent_type', 'PairingIntent'], ['equal', 'DevicePairingPhrase', 'pair my device']]]
 Evaluating message: {'lang': 'en-us', 'skill_id': 1211234571, 'utterances': [u"let's pair my device"]}
@@ -302,10 +302,10 @@ else:
 > raise Exception('Skill couldn't be loaded')
 E Exception: Skill couldn't be loaded
 test/integrationtests/skills/skill_tester.py:198: Exception
-TestCase.test_skill[/opt/mycroft/skills/skill-alarm-/opt/mycroft/skills/skill-alarm/test/intent/sample7.intent.json]
+TestCase.test_skill[/home/username/.local/share/mycroft/skills/skill-alarm-/home/username/.local/share/mycroft/skills/skill-alarm/test/intent/sample7.intent.json]
 self =
-skill = '/opt/mycroft/skills/skill-alarm'
-example = '/opt/mycroft/skills/skill-alarm/test/intent/sample7.intent.json'
+skill = '/home/username/.local/share/mycroft/skills/skill-alarm'
+example = '/home/username/.local/share/mycroft/skills/skill-alarm/test/intent/sample7.intent.json'
 @pytest.mark.parametrize("skill,example", sum([
 [(skill, example) for example in tests[skill]]
 for skill in tests.keys()
@@ -321,7 +321,7 @@ The last section of the Integration Test Runner output shows the test coverage -
 ---------- coverage: platform linux2, python 2.7.12-final-0 ----------
 Name Stmts Miss Cover
 -----------------------------------------------------------------
-/opt/mycroft/skills/skill-alarm/__init__.py 293 290 1%
+/home/username/.local/share/mycroft/skills/skill-alarm/__init__.py 293 290 1%
 ```
 
 ## What should I do if the tests that are failing are not within my control?

--- a/docs/skill-development/voight-kampff/test-runner.md
+++ b/docs/skill-development/voight-kampff/test-runner.md
@@ -155,7 +155,7 @@ To reset the tts settings to default run:
 
 ### Editing `mycroft.conf`
 
-You can also make the adjustment by editing the config file directly `~/.mycroft/mycroft.conf`.
+You can also make the adjustment by editing the config file directly `~/.config/mycroft/mycroft.conf`.
 
 ```javascript
 {

--- a/docs/using-mycroft-ai/customizations/config-manager.md
+++ b/docs/using-mycroft-ai/customizations/config-manager.md
@@ -11,10 +11,11 @@ description: >-
 
 Mycroft configurations are stored in [mycroft.conf](mycroft-conf.md) files. These exist in four locations:
 
-* Default - mycroft-core/mycroft/configuration/mycroft.conf
+* Default - `mycroft-core/mycroft/configuration/mycroft.conf`
 * Remote - Home.Mycroft.ai
-* System - /etc/mycroft/mycroft.conf
-* User - $HOME/.mycroft/mycroft.conf
+* System - `/etc/mycroft/mycroft.conf`
+* User - `$HOME/.config/mycroft/mycroft.conf`
+* Old user (deprecated) - `$HOME/.mycroft/mycroft.conf`
 
 When the configuration loader starts, it looks in these locations in this order, and loads **all** configurations. Keys that exist in multiple configuration files will be overridden by the last file to contain the value.
 

--- a/docs/using-mycroft-ai/customizations/languages/README.md
+++ b/docs/using-mycroft-ai/customizations/languages/README.md
@@ -122,7 +122,7 @@ In order to support a new language, individual Skills must support that language
 
 To have a Skill support another language, the easiest way is to contribute to translating `dialog` and `vocab` files on the [Mycroft Translate](https://translate.mycroft.ai) platform. When significant progress has been made on a language in Mycroft Translate, the translations are automatically added to Skills.
 
-You can modify the individual `dialog` and `vocab` files for a Skill on your own device if you need to. Each Skill is in it's own directory on your device at `/opt/mycroft/skills/`.
+You can modify the individual `dialog` and `vocab` files for a Skill on your own device if you need to. Each Skill is in it's own directory on your device at `$HOME/.local/share/mycroft/skills/`.
 
 ## 6. Mycroft Core - Lingua Franca library
 

--- a/docs/using-mycroft-ai/customizations/mycroft-conf.md
+++ b/docs/using-mycroft-ai/customizations/mycroft-conf.md
@@ -16,10 +16,11 @@ See a [list of all variables available within `mycroft.conf`](https://github.com
 
 The `mycroft.conf` files are stored in four possible locations:
 
-1. Default - mycroft-core/mycroft/configuration/mycroft.conf
-2. Remote \(from Home.Mycroft.ai\) - /var/tmp/mycroft\_web\_cache.json
-3. System - /etc/mycroft/mycroft.conf
-4. User - $HOME/.mycroft/mycroft.conf
+* Default - `mycroft-core/mycroft/configuration/mycroft.conf`
+* Remote - Home.Mycroft.ai
+* System - `/etc/mycroft/mycroft.conf`
+* User - `$HOME/.config/mycroft/mycroft.conf`
+* Old user (deprecated) - `$HOME/.mycroft/mycroft.conf`
 
 Mycroft implements an order of precedence; settings defined at a User level override those at a System level. If the file does not exist, Mycroft moves to the following level.
 
@@ -51,21 +52,18 @@ pi@mark_1:/etc/mycroft $ cat mycroft.conf
 See a [list of all variables available within `mycroft.conf`](https://github.com/MycroftAI/mycroft-core/blob/master/mycroft/configuration/mycroft.conf)\`\`
 {% endhint %}
 
-## `mycroft_web_cache.json`
+## `web_cache.json`
 
-`mycroft_web_cache.json` is is a [JSON](https://www.json.org/)-formatted file that is saved locally on your Mycroft Device, such as Picroft or Mark 1. `mycroft_web_cache.json` is a cached copy of the settings on your [home.mycroft.ai](https://home.mycroft.ai) account, such as your _Location_ \(which determines _Time Zone_\), which _Voice_ you have selected and your preference for _Measurements_ such as temperature and distance.
+`web_cache.json` is is a [JSON](https://www.json.org/)-formatted file that is saved locally on your Mycroft Device, such as Picroft or Mark 1.
+`web_cache.json` is a cached copy of the settings on your [home.mycroft.ai](https://home.mycroft.ai) account, such as your _Location_ \(which determines _Time Zone_\), which _Voice_ you have selected and your preference for _Measurements_ such as temperature and distance.
 
 Both of these files are regularly used in troubleshooting, so it's useful to know what information they hold, and where they are stored on your Device.
 
-### Where is the `mycroft_web_cache.json` file stored?
+### Where is the `web_cache.json` file stored?
 
-This file is stored at:
+This file is stored on the device at `$HOME/.cache/mycroft/web_cache.json`.
 
-`/var/tmp/mycroft_web_cache.json`
-
-on the Device.
-
-### How is `mycroft_web_cache.json` updated?
+### How is `web_cache.json` updated?
 
 When you update settings at [home.mycroft.ai](https://home.mycroft.ai), your Device will periodically pull them down. In normal circumstances any change should be reflected on the device within 1-2 minutes. You can also instruct your device to pull down the latest configuration, by saying:
 
@@ -81,35 +79,35 @@ Mycroft will respond in one of two ways:
 
 > Your device has been configured
 
-### Reading values directly from `mycroft_web_cache.json`
+### Reading values directly from `web_cache.json`
 
 To see the city location value:
 
-`jq ".location.city" < /var/tmp/mycroft_web_cache.json`
+`jq ".location.city" < $HOME/.cache/mycroft/web_cache.json`
 
 To see the latitude and longitude coordinates of your location:
 
-`jq ".location.coordinate" < /var/tmp/mycroft_web_cache.json`
+`jq ".location.coordinate" < $HOME/.cache/mycroft/web_cache.json`
 
 To see the timezone setting:
 
-`jq ".location.timezone" < /var/tmp/mycroft_web_cache.json`
+`jq ".location.timezone" < $HOME/.cache/mycroft/web_cache.json`
 
 To see the listener setting:
 
-`jq ".listener" < /var/tmp/mycroft_web_cache.json`
+`jq ".listener" < $HOME/.cache/mycroft/web_cache.json`
 
 To see the Speech to Text \(STT\) settings:
 
-`jq ".stt" < /var/tmp/mycroft_web_cache.json`
+`jq ".stt" < $HOME/.cache/mycroft/web_cache.json`
 
 To see the Text to Speech \(TTS\) settings:
 
-`jq ".tts" < /var/tmp/mycroft_web_cache.json`
+`jq ".tts" < $HOME/.cache/mycroft/web_cache.json`
 
-### A look at the inside of `mycroft_web_cache.json`
+### A look at the inside of `web_cache.json`
 
-Here is an example `mycroft_web_cache.json`.  
+Here is an example `web_cache.json`.  
 _NOTE: Your settings will be different._
 
 ```javascript
@@ -154,8 +152,7 @@ _NOTE: Your settings will be different._
     "wake_word": "hey mycroft"
   },
   "time_format": "full",
-  "skills": {
-    "directory": "~/.mycroft/skills",
+  "skills": { 
     "created_at": 1504481866994,
     "updated_at": 1514794901226,
     "stop_threshold": 2

--- a/docs/using-mycroft-ai/customizations/wake-word.md
+++ b/docs/using-mycroft-ai/customizations/wake-word.md
@@ -35,7 +35,7 @@ For this example we shall use a pre-trained model named `computer-en`. Each mode
 * `computer-en.pb` - the model itself; and
 * `computer-en.pb.params` - a small configuration file containing the parameters for that model.
 
-The two files must be consistently named as they are in the example above. They must also be stored in the same directory, however it does not matter where on the file system this directory is as we will point Mycroft to them. By default Mycroft stores these in your home directory at `~/.mycroft/precise`. Multiple models can be on your system at any given time so we can leave any existing model files there.
+The two files must be consistently named as they are in the example above. They must also be stored in the same directory, however it does not matter where on the file system this directory is as we will point Mycroft to them. By default Mycroft stores these in your home directory at `~/.local/share/mycroft/precise`. Multiple models can be on your system at any given time so we can leave any existing model files there.
 
 Once you have your Wake Word model, you must tell Mycroft which model you want to use in your [`mycroft.conf`](mycroft-conf.md) file. This is best done using the [Configuration Manager](config-manager.md). To edit your User level configuration run:
 
@@ -49,7 +49,7 @@ We will then define our Wake Word and any attributes we want to give it. Each ho
 "hotwords": {
   "computer": {
       "module": "precise",
-      "local_model_file": "/home/pi/.mycroft/precise/computer-en.pb",
+      "local_model_file": "/home/pi/.config/mycroft/precise/computer-en.pb",
   }
 }
 ```
@@ -88,7 +88,7 @@ Putting the example above together in an otherwise unmodified User level `mycrof
   "hotwords": {
     "computer": {
         "module": "precise",
-        "local_model_file": "/home/user/.mycroft/precise/computer-en.pb",
+        "local_model_file": "/home/user/.config/mycroft/precise/computer-en.pb",
         "sensitivity": 0.1,
         "trigger_level": 7
     }
@@ -99,8 +99,8 @@ Putting the example above together in an otherwise unmodified User level `mycrof
 {% hint style="info" %}
 Remember in the example above, there must be two files for the model to operate:
 
-* `/home/user/.mycroft/precise/computer-en.pb`
-* `/home/user/.mycroft/precise/computer-en.pb.params`
+* `/home/user/.config/mycroft/precise/computer-en.pb`
+* `/home/user/.config/mycroft/precise/computer-en.pb.params`
 {% endhint %}
 
 ## PocketSphinx
@@ -164,7 +164,7 @@ Other settings are available to further tune how sensitive the Speech to Text \(
 
 #### Adding PocketSphinx Settings to `mycroft.conf`
 
-For the `Yo Mike` example we started with, an example `~/.mycroft/mycroft.conf` file might look like:
+For the `Yo Mike` example we started with, an example `~/.config/mycroft/mycroft.conf` file might look like:
 
 ```javascript
 {

--- a/docs/using-mycroft-ai/file-locations.md
+++ b/docs/using-mycroft-ai/file-locations.md
@@ -1,0 +1,33 @@
+---
+description: >-
+  Mycroft stores file in various locations which can be changed by the user using some environment variables
+---
+
+# XDG Base directory specification
+
+Mycroft follows the [Freedesktop XDG Base directory specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
+This means that files and folders aren't stored to a single directory, but split out to several directories depending on their function.
+It also means that although there are default locations, they can be modified by the user using environment variables if they so desire.
+
+By default the directories used are:
+
+- `$XDG_CONFIG_HOME/mycroft` for configuration
+- `$XDG_DATA_HOME/mycroft` for persistent data storage
+- `$XDG_CACHE_HOME/mycroft` for non-essential data
+
+These variables can be set to anything the user desires and Mycroft will automatically change where it's stores it's data and configuration.
+Previously Mycroft used to store everything under `$HOME/.mycroft` which can be replicated quite easily if so desired:
+
+```bash
+export XDG_CONFIG_HOME=$HOME/.mycroft
+export XDG_DATA_HOME=$HOME/.mycroft
+export XDG_CACHE_HOME=$HOME/.mycroft
+```
+
+If the above mentioned variables don't exist, which will be the case for the majority of people, Mycroft will use the following default values:
+
+- `$HOME/.config/mycroft` for configuration
+- `$HOME/.local/share/mycroft` for persistent data storage
+- `$HOME/.cache/mycroft` for non-essential data
+
+These default values are used in the Mycroft documentation, but can as mentioned be changed to the XDG variables.

--- a/docs/using-mycroft-ai/get-mycroft/linux.md
+++ b/docs/using-mycroft-ai/get-mycroft/linux.md
@@ -229,12 +229,20 @@ rm -rf ~/mycroft-core
 Alternatively you can manually remove these files using the following commands:
 
 ```bash
-sudo rm -rf /var/log/mycroft # Log files
-rm -f /var/tmp/mycroft_web_cache.json # Configuration from Home.mycroft.ai
+rm -rf $HOME/.cache/mycroft/ # Log files and remote configuration files
 rm -rf "${TMPDIR:-/tmp}/mycroft" # Temp files
-rm -rf "$HOME/.mycroft" # User level configuration
-sudo rm -rf /opt/mycroft # Mycroft Skills directory
+rm -rf "$HOME/.config/mycroft" # User level configuration
+rm -rf $HOME/.local/share/mycroft # Mycroft Skills directory
 rm -rf "$HOME/mycroft-core" # Mycroft-core installation
+```
+
+Previous versions of Mycroft also stored data at some other locations.
+If you have updated your Mycroft instsallation over time, these directories may still exist and can also be removed:
+
+```bash
+rm -r /opt/mycroft
+rm -r /var/log/mycroft
+rm -r $HOME/.mycroft
 ```
 
 {% hint style="info" %}

--- a/docs/using-mycroft-ai/get-mycroft/picroft.md
+++ b/docs/using-mycroft-ai/get-mycroft/picroft.md
@@ -339,11 +339,11 @@ There are several commands that are packaged into Picroft to help you with advan
 
 If you plan to do **Skills** development work, or other development work with Picroft, you'll find knowing these file locations useful.
 
-* Skills - have a shortcut in `/home/pi` that points to `/opt/mycroft/skills`
+* Skills - have a shortcut in `/home/pi` that points to `/home/mycroft/.local/share/mycroft/skills`
 * `mycroft-core` - is located at `/home/pi/mycroft-core`
-* Logs - are located at `/var/log/mycroft/`
-* `mycroft.conf` - is located at `/home/mycroft/.mycroft/mycroft.conf`
-* Identity file \(do not share\) - is located at `/home/mycroft/.mycroft/identity/identity2.json`
+* Logs - are located at `/home/mycroft/.cache/mycroft/`
+* `mycroft.conf` - is located at `/home/mycroft/.config/mycroft/mycroft.conf`
+* Identity file \(do not share\) - is located at `/home/mycroft/.config/mycroft/identity/identity2.json`
 
 ### Maintaining your Picroft
 

--- a/docs/using-mycroft-ai/pairing-your-device.md
+++ b/docs/using-mycroft-ai/pairing-your-device.md
@@ -86,7 +86,7 @@ Congratulations! Your Mycroft Device is now paired, and is ready to start accept
 
 Once you have paired your Mycroft Device, pairing information is stored in:
 
-`~/.mycroft/identity/identity2.json`
+`~/.config/mycroft/identity/identity2.json`
 
 DO NOT SHARE THIS INFORMATION WITH OTHERS - IT IS YOUR MYCROFT IDENTITY
 

--- a/docs/using-mycroft-ai/troubleshooting/general-troubleshooting.md
+++ b/docs/using-mycroft-ai/troubleshooting/general-troubleshooting.md
@@ -152,7 +152,7 @@ Traceback (most recent call last):
     skill.settings.store()
   File "/usr/local/lib/python2.7/site-packages/mycroft_core-0.9.7-py2.7.egg/mycroft/skills/settings.py", line 323, in store
     with open(self._settings_path, 'w') as f:
-IOError: [Errno 13] Permission denied: '/opt/mycroft/skills/mycroft-skill-cat-facts/settings.json'
+IOError: [Errno 13] Permission denied: '/home/mycroft/.local/share/mycroft/skills/mycroft-skill-cat-facts/settings.json'
 ```
 
 The error here is that the file system permission on the Skill's directory are incorrect. The directory should have owner and group permissions of `mycroft:mycroft` as per the below.
@@ -173,7 +173,7 @@ The error here is that the file system permission on the Skill's directory are i
 If your permissions are different to those shown above, change them by running the following commands:
 
 ```bash
-cd /opt/mycroft/skills/
+cd /home/mycroft/.local/share/mycroft/skills/
 sudo chown mycroft:mycroft -R your-skill-name
 ```
 


### PR DESCRIPTION
Depends on:

- https://github.com/MycroftAI/mycroft-core/pull/2794
- https://github.com/MycroftAI/mycroft-core/pull/2803
- https://github.com/MycroftAI/mycroft-skills-manager/pull/88
- https://github.com/MycroftAI/mycroft-skills-manager/pull/90

#### Description
Updates the documentation to use XDG locations. I decided to use e.g. `$HOME/.config` rather than `$XDG_CONFIG_DIR` as most people will not have the XDG variables set, and the ones who do know what they're doing already and should realize by themselves they have to update the locations as shown.

Please check properly if I missed anything or made mistakes, this was just done using some quick `grep -r` and I might've misunderstood certain locations as used by e.g. Docker or the Mark 1 device.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [ ] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [x] Documentation improvements
- [ ] Test improvements