### PR TITLE
tts/mozila: fix wrong api path

### DIFF
--- a/docs/using-mycroft-ai/customizations/tts-engine.md
+++ b/docs/using-mycroft-ai/customizations/tts-engine.md
@@ -319,12 +319,12 @@ To our existing configuration values we will add the following:
 "tts": {
   "module": "mozilla",
   "mozilla": {
-    "url": "http://my-mozilla-tts-server/api/tts"
+    "url": "http://my-mozilla-tts-server"
   }
 }
 ```
 
-By default the `url` is set to the localhost: [`http://0.0.0.0:5002/api/tts`](http://0.0.0.0:5002/api/tts) So if you are running the server on the same machine as your Mycroft instance, only the `module` attribute needs to be set. This can also be done with a single command:
+By default the `url` is set to the localhost: [`http://0.0.0.0:5002`](http://0.0.0.0:5002) So if you are running the server on the same machine as your Mycroft instance, only the `module` attribute needs to be set. This can also be done with a single command:
 
 ```bash
 mycroft-config set tts.module mozilla


### PR DESCRIPTION
The module appends `/api/tts`, so users should not provide this string or it won't work, see
https://github.com/MycroftAI/mycroft-core/blob/a487f66958b759342d055e3f61add6dd594be485/mycroft/tts/mozilla_tts.py#L30

### How to use this template
Under each heading below is a short outline of the information required. When submitting a PR, please delete this text and replace it with your own. 


#### Description
Please start with one or two sentence description of what this pull request does. 
Eg “fixes #{issue number}” or “Adds {feature} to {component}”

If needed follow up with as much detail as required.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [ ] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [x] Documentation improvements
- [ ] Test improvements

#### Testing
1. Set up mozilla tts
2. Use a non-standard tts url:

```
 "tts": {
   "module": "mozilla",
   "mozilla": {
     "url": "http://tts.yourdomain"
   }
 }
```

